### PR TITLE
Add rpi_exporter.service for systemd

### DIFF
--- a/.promu.yml
+++ b/.promu.yml
@@ -21,6 +21,7 @@ tarball:
     files:
         - LICENSE
         - NOTICE
+        - systemd/rpi_exporter.service
 crossbuild:
     platforms:
         - linux/arm

--- a/systemd/rpi_exporter.service
+++ b/systemd/rpi_exporter.service
@@ -1,0 +1,13 @@
+[Unit]
+Description=Prometheus exporter for RPi temperature metrics
+Documentation=https://github.com/lukasmalkmus/rpi_exporter
+
+[Service]
+Restart=always
+User=prometheus
+ExecStart=/usr/local/bin/rpi_exporter
+TimeoutStopSec=20s
+SendSIGKILL=no
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
Adding systemd service file to allow rpi_exporter start during boot + be managed by systemd.