### PR TITLE
Add CPU and GPU frequency metrics

### DIFF
--- a/collector/cpu.go
+++ b/collector/cpu.go
@@ -23,7 +23,9 @@ import (
 
 const cpuSubsystem = "cpu"
 
-type cpuCollector struct{}
+type cpuCollector struct{
+	cpuTempCelsius	*prometheus.Desc
+}
 
 func init() {
 	registerCollector("cpu", defaultEnabled, NewCPUCollector)
@@ -31,7 +33,14 @@ func init() {
 
 // NewCPUCollector returns a new Collector exposing CPU temperature metrics.
 func NewCPUCollector() (Collector, error) {
-	return &cpuCollector{}, nil
+	cc := &cpuCollector{
+		cpuTempCelsius: prometheus.NewDesc(
+                        prometheus.BuildFQName(namespace, cpuSubsystem, "temperature_celsius"),
+                        "CPU temperature in degrees celsius (°C).",
+                        nil, nil,
+                ),
+	}
+	return cc, nil
 }
 
 // Update implements the Collector interface.
@@ -50,11 +59,7 @@ func (c *cpuCollector) Update(ch chan<- prometheus.Metric) error {
 
 	// Export the metric.
 	ch <- prometheus.MustNewConstMetric(
-		prometheus.NewDesc(
-			prometheus.BuildFQName(namespace, cpuSubsystem, "temperature_celsius"),
-			"CPU temperature in degrees celsius (°C).",
-			nil, nil,
-		),
+		c.cpuTempCelsius,
 		prometheus.GaugeValue, temp,
 	)
 	return nil

--- a/collector/cpu.go
+++ b/collector/cpu.go
@@ -16,6 +16,7 @@ package collector
 import (
 	"bytes"
 	"io/ioutil"
+	"path/filepath"
 	"strconv"
 
 	"github.com/prometheus/client_golang/prometheus"
@@ -25,6 +26,7 @@ const cpuSubsystem = "cpu"
 
 type cpuCollector struct{
 	cpuTempCelsius	*prometheus.Desc
+	cpuFreqHertz	*prometheus.Desc
 }
 
 func init() {
@@ -39,13 +41,18 @@ func NewCPUCollector() (Collector, error) {
                         "CPU temperature in degrees celsius (°C).",
                         nil, nil,
                 ),
+		cpuFreqHertz: prometheus.NewDesc(
+			prometheus.BuildFQName(namespace, cpuSubsystem, "frequency_hertz"),
+			"CPU Frequency in hertz (Hz).",
+			[]string{"cpu"}, nil,
+		),
 	}
 	return cc, nil
 }
 
 // Update implements the Collector interface.
 func (c *cpuCollector) Update(ch chan<- prometheus.Metric) error {
-	// Get temperature string from /sys/class/thermal/thermal_zone*/temp and
+	// Get temperature string from /sys/class/thermal/thermal_zone0/temp and
 	// convert it to float64 value.
 	b, err := ioutil.ReadFile("/sys/class/thermal/thermal_zone0/temp")
 	if err != nil {
@@ -62,5 +69,35 @@ func (c *cpuCollector) Update(ch chan<- prometheus.Metric) error {
 		c.cpuTempCelsius,
 		prometheus.GaugeValue, temp,
 	)
+
+	// Get all the cpus from /sys/devices/system/cpu/cpu*.
+	cpus, err := filepath.Glob("/sys/devices/system/cpu/cpu[0-9]*")
+	if err != nil {
+		return err
+	}
+
+	for i, cpu := range cpus {
+		// Get the frequency string from /sys/devices/system/cpu/cpu*/cpufreq/scaling_cur_freq
+		// and convert it to a float64 value.
+		// Use scaling_cur_freq rather than cpuinfo_cur_freq because that seems to be
+		// more accurate, according to the internet.
+		b, err = ioutil.ReadFile(cpu + "/cpufreq/scaling_cur_freq")
+		if err != nil {
+			return err
+		}
+		freq, err := strconv.ParseFloat(string(bytes.TrimSpace(b)), 64)
+		if err != nil {
+			return err
+		}
+
+		// Export the metric.
+		ch <- prometheus.MustNewConstMetric(
+			c.cpuFreqHertz,
+			prometheus.GaugeValue,
+			freq,
+			strconv.Itoa(i),
+		)
+	}
+
 	return nil
 }

--- a/collector/gpu.go
+++ b/collector/gpu.go
@@ -31,7 +31,8 @@ var (
 )
 
 type gpuCollector struct {
-	vcgencmd string
+	vcgencmd	string
+	gpuTempCelsius	*prometheus.Desc
 }
 
 func init() {
@@ -40,7 +41,14 @@ func init() {
 
 // NewGPUCollector returns a new Collector exposing GPU temperature metrics.
 func NewGPUCollector() (Collector, error) {
-	gc := &gpuCollector{*vcgencmd}
+	gc := &gpuCollector{
+		vcgencmd: *vcgencmd,
+		gpuTempCelsius: prometheus.NewDesc(
+                        prometheus.BuildFQName(namespace, gpuSubsystem, "temperature_celsius"),
+                        "GPU temperature in degrees celsius (°C).",
+                        nil, nil,
+                ),
+	}
 	return gc, nil
 }
 
@@ -64,11 +72,7 @@ func (c *gpuCollector) Update(ch chan<- prometheus.Metric) error {
 
 	// Export the metric.
 	ch <- prometheus.MustNewConstMetric(
-		prometheus.NewDesc(
-			prometheus.BuildFQName(namespace, gpuSubsystem, "temperature_celsius"),
-			"GPU temperature in degrees celsius (°C).",
-			nil, nil,
-		),
+		c.gpuTempCelsius,
 		prometheus.GaugeValue, temp,
 	)
 	return nil


### PR DESCRIPTION
This PR adds metrics for the per core CPU frequency, as well as the three GPU components whose frequency can be checked using `vcgencmd measure_clock`.

It also avoids recreating the `prometheus.Desc` for every /metrics request.

I did test this, however I didn't test this with older raspbian versions, so I'm not sure how new it has to be for this to work.