### PR TITLE
Store prometheus http handlers instead of recreating them for every request

### DIFF
--- a/collector/cpu.go
+++ b/collector/cpu.go
@@ -24,9 +24,9 @@ import (
 
 const cpuSubsystem = "cpu"
 
-type cpuCollector struct{
-	cpuTempCelsius	*prometheus.Desc
-	cpuFreqHertz	*prometheus.Desc
+type cpuCollector struct {
+	cpuTempCelsius *prometheus.Desc
+	cpuFreqHertz   *prometheus.Desc
 }
 
 func init() {
@@ -37,10 +37,10 @@ func init() {
 func NewCPUCollector() (Collector, error) {
 	cc := &cpuCollector{
 		cpuTempCelsius: prometheus.NewDesc(
-                        prometheus.BuildFQName(namespace, cpuSubsystem, "temperature_celsius"),
-                        "CPU temperature in degrees celsius (°C).",
-                        nil, nil,
-                ),
+			prometheus.BuildFQName(namespace, cpuSubsystem, "temperature_celsius"),
+			"CPU temperature in degrees celsius (°C).",
+			nil, nil,
+		),
 		cpuFreqHertz: prometheus.NewDesc(
 			prometheus.BuildFQName(namespace, cpuSubsystem, "frequency_hertz"),
 			"CPU Frequency in hertz (Hz).",

--- a/collector/gpu.go
+++ b/collector/gpu.go
@@ -37,9 +37,9 @@ var (
 )
 
 type gpuCollector struct {
-	vcgencmd	string
-	gpuTempCelsius	*prometheus.Desc
-	gpuFreqHertz	*prometheus.Desc
+	vcgencmd       string
+	gpuTempCelsius *prometheus.Desc
+	gpuFreqHertz   *prometheus.Desc
 }
 
 func init() {
@@ -51,10 +51,10 @@ func NewGPUCollector() (Collector, error) {
 	gc := &gpuCollector{
 		vcgencmd: *vcgencmd,
 		gpuTempCelsius: prometheus.NewDesc(
-                        prometheus.BuildFQName(namespace, gpuSubsystem, "temperature_celsius"),
-                        "GPU temperature in degrees celsius (°C).",
-                        nil, nil,
-                ),
+			prometheus.BuildFQName(namespace, gpuSubsystem, "temperature_celsius"),
+			"GPU temperature in degrees celsius (°C).",
+			nil, nil,
+		),
 		gpuFreqHertz: prometheus.NewDesc(
 			prometheus.BuildFQName(namespace, gpuSubsystem, "frequency_hertz"),
 			"GPU frequency in hertz (Hz).",
@@ -78,7 +78,7 @@ func (c *gpuCollector) Update(ch chan<- prometheus.Metric) error {
 	tempStr := string(stdout)
 	idx := strings.IndexByte(tempStr, '=')
 	if idx != -1 {
-		tempStr = tempStr[idx + 1:]
+		tempStr = tempStr[idx+1:]
 	}
 	tempStr = strings.TrimSuffix(tempStr, "'C\n")
 	temp, err := strconv.ParseFloat(tempStr, 64)
@@ -105,7 +105,7 @@ func (c *gpuCollector) Update(ch chan<- prometheus.Metric) error {
 		freqStr := string(stdout)
 		idx = strings.IndexByte(freqStr, '=')
 		if idx != -1 {
-			freqStr = freqStr[idx + 1:]
+			freqStr = freqStr[idx+1:]
 		}
 		freqStr = strings.TrimSuffix(freqStr, "\n")
 		freq, err := strconv.ParseFloat(freqStr, 64)


### PR DESCRIPTION
This PR changes the http handler to store the internal `http.Handler` object for every filter combination, instead of recreating them for every request.

The node exporter only stores the unfiltered one, and recreates the filtered ones, if they are needed.  
I believe it is fine to store the filtered ones in this project, because having only 3 collectors means there are 7 filter combinations(plus the unfiltered one) at most.  
However I would be fine with recreating the filtered ones, if you believe this isn't worth the additional RAM it uses.

Closes #22